### PR TITLE
fix: allow deleting all cluster-scoped resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,12 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kr/text v0.2.0 // indirect
+	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -38,8 +41,10 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.33.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,6 @@ buf.build/gen/go/spectrocloud/spectro-cleanup/protocolbuffers/go v1.31.0-2023121
 connectrpc.com/connect v1.13.0 h1:lGs5maZZzWOOD+PFFiOt5OncKmMsk9ZdPwpy5jcmaYg=
 connectrpc.com/connect v1.13.0/go.mod h1:uHAFHtYgeSZJxXrkN1IunDpKghnTXhYbVh0wW4StPW0=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -22,6 +21,8 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZU=
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
+github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
+github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -33,6 +34,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
+github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -60,6 +63,10 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=
+github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
+github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
+github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -117,6 +124,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/cleaner/cleaner.go
+++ b/internal/cleaner/cleaner.go
@@ -282,7 +282,7 @@ func (c *Cleaner) deleteAllResources(ctx context.Context, dc dynamic.Interface, 
 		Str("namespace", obj.Namespace).
 		Msg("deleting all resources of type")
 
-	isClusterScoped, err := isResourceClusterScoped(rm, obj.GroupVersionResource)
+	clusterScoped, err := isResourceClusterScoped(rm, obj.GroupVersionResource)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to determine resource scope")
 		return err
@@ -290,7 +290,7 @@ func (c *Cleaner) deleteAllResources(ctx context.Context, dc dynamic.Interface, 
 
 	var resources unstructured.UnstructuredList
 
-	switch isClusterScoped {
+	switch clusterScoped {
 	case true:
 		// For cluster-scoped resources, list at cluster level
 		list, err := dc.Resource(obj.GroupVersionResource).List(ctx, metav1.ListOptions{})

--- a/internal/cleaner/cleaner.go
+++ b/internal/cleaner/cleaner.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -75,7 +76,7 @@ type DeleteObj struct {
 	Name string `json:"name,omitempty"`
 
 	// Namespace is the namespace of the resource to be deleted. Omit when deleting all resources for this GVR
-	// across all namespaces, or when deleting a single cluster-scoped resource.
+	// across all namespaces, or when deleting one or all of a cluster-scoped resources.
 	Namespace string `json:"namespace,omitempty"`
 
 	// MustDelete is a flag that indicates if the resource must be deleted.
@@ -154,7 +155,7 @@ func (c *Cleaner) CleanupFiles() error {
 }
 
 // CleanupResources deletes all K8s resources specified in the resource cleanup config file.
-func (c *Cleaner) CleanupResources(ctx context.Context, dc dynamic.Interface) error {
+func (c *Cleaner) CleanupResources(ctx context.Context, dc dynamic.Interface, rm meta.RESTMapper) error {
 	resources := []DeleteObj{}
 	bytes, err := readConfig(c.ResourceConfigPath, resourcesToDelete)
 	if err != nil {
@@ -194,7 +195,7 @@ func (c *Cleaner) CleanupResources(ctx context.Context, dc dynamic.Interface) er
 
 		var err error
 		if obj.Name == "" {
-			err = c.deleteAllResources(ctx, dc, obj)
+			err = c.deleteAllResources(ctx, dc, rm, obj)
 		} else {
 			log.Info().
 				Str("gvr", obj.GroupVersionResource.String()).
@@ -274,36 +275,60 @@ func (c *Cleaner) deleteSingleResource(ctx context.Context, dc dynamic.Interface
 
 // deleteAllResources handles deletion of all resources of a given GVR.
 // If a namespace is specified, only resources in that namespace will be deleted.
-// If a namespace is not specified, all resources in all namespaces will be deleted.
-func (c *Cleaner) deleteAllResources(ctx context.Context, dc dynamic.Interface, obj DeleteObj) error {
+// If a namespace is not specified, all resources will be deleted.
+func (c *Cleaner) deleteAllResources(ctx context.Context, dc dynamic.Interface, rm meta.RESTMapper, obj DeleteObj) error {
 	log.Info().
 		Str("gvr", obj.GroupVersionResource.String()).
 		Str("namespace", obj.Namespace).
 		Msg("deleting all resources of type")
 
-	resources := unstructured.UnstructuredList{}
-
-	namespaces, err := dc.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
+	// Determine if this is a cluster-scoped or namespaced resource
+	// by attempting to list at cluster level
+	isClusterScoped, err := isResourceClusterScoped(rm, obj.GroupVersionResource)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to list namespaces")
+		log.Error().Err(err).Msg("failed to determine resource scope")
 		return err
 	}
-	for _, namespace := range namespaces.Items {
-		ns := namespace.GetName()
-		if obj.Namespace != "" && obj.Namespace != ns {
-			log.Info().
-				Str("gvr", obj.GroupVersionResource.String()).
-				Str("namespace", ns).
-				Msg("skipping namespace")
-			continue
-		}
-		list, err := dc.Resource(obj.GroupVersionResource).Namespace(ns).List(ctx, metav1.ListOptions{})
+
+	var resources unstructured.UnstructuredList
+
+	switch isClusterScoped {
+	case true:
+		// For cluster-scoped resources, list at cluster level
+		list, err := dc.Resource(obj.GroupVersionResource).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			log.Error().Err(err).Msg("failed to list resources")
+			log.Error().Err(err).Msg("failed to list cluster-scoped resources")
 			return err
 		}
-		resources.Items = append(resources.Items, list.Items...)
+		resources.Items = list.Items
+		log.Info().
+			Str("gvr", obj.GroupVersionResource.String()).
+			Int("count", len(resources.Items)).
+			Msg("found cluster-scoped resources")
+	case false:
+		namespaces, err := dc.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			log.Error().Err(err).Msg("failed to list namespaces")
+			return err
+		}
+		for _, namespace := range namespaces.Items {
+			ns := namespace.GetName()
+			if obj.Namespace != "" && obj.Namespace != ns {
+				log.Info().
+					Str("gvr", obj.GroupVersionResource.String()).
+					Str("namespace", ns).
+					Msg("skipping namespace")
+				continue
+			}
+			list, err := dc.Resource(obj.GroupVersionResource).Namespace(ns).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				log.Error().Err(err).Msg("failed to list resources")
+				return err
+			}
+			resources.Items = append(resources.Items, list.Items...)
+		}
 	}
+
 	if len(resources.Items) == 0 {
 		log.Warn().
 			Str("gvr", obj.GroupVersionResource.String()).
@@ -316,6 +341,21 @@ func (c *Cleaner) deleteAllResources(ctx context.Context, dc dynamic.Interface, 
 		return c.deleteAllResourcesBlocking(ctx, dc, obj, resources.Items)
 	}
 	return c.deleteAllResourcesNonBlocking(ctx, dc, obj, resources.Items)
+}
+
+// isResourceClusterScoped determines if a resource is cluster-scoped or namespaced
+func isResourceClusterScoped(rm meta.RESTMapper, gvr schema.GroupVersionResource) (bool, error) {
+	// Resolve GVR -> GVK, then get a RESTMapping (which includes Scope)
+	gvk, err := rm.KindFor(gvr)
+	if err != nil {
+		return false, err
+	}
+	mapping, err := rm.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return false, err
+	}
+
+	return mapping.Scope.Name() != meta.RESTScopeNameNamespace, nil
 }
 
 // deleteAllResourcesBlocking handles deletion of all resources with blocking behavior

--- a/internal/cleaner/cleaner.go
+++ b/internal/cleaner/cleaner.go
@@ -282,8 +282,6 @@ func (c *Cleaner) deleteAllResources(ctx context.Context, dc dynamic.Interface, 
 		Str("namespace", obj.Namespace).
 		Msg("deleting all resources of type")
 
-	// Determine if this is a cluster-scoped or namespaced resource
-	// by attempting to list at cluster level
 	isClusterScoped, err := isResourceClusterScoped(rm, obj.GroupVersionResource)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to determine resource scope")
@@ -306,6 +304,7 @@ func (c *Cleaner) deleteAllResources(ctx context.Context, dc dynamic.Interface, 
 			Int("count", len(resources.Items)).
 			Msg("found cluster-scoped resources")
 	case false:
+		// For namespaced resources, check each namespace
 		namespaces, err := dc.Resource(namespaceGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			log.Error().Err(err).Msg("failed to list namespaces")

--- a/internal/cleaner/cleaner_test.go
+++ b/internal/cleaner/cleaner_test.go
@@ -412,10 +412,69 @@ func TestCleanupResources(t *testing.T) {
 			})
 			tt.mockSetup(mockClient)
 
+			// Setup mock REST mapper
+			mockMapper := mock.NewRESTMapper()
+
 			// Run the cleanup
-			err = tt.cleaner.CleanupResources(ctx, mockClient)
+			err = tt.cleaner.CleanupResources(ctx, mockClient, mockMapper)
 			if (err != nil) != tt.expectedError {
 				t.Errorf("expected error %v, got %v", tt.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestIsResourceClusterScoped(t *testing.T) {
+	tests := []struct {
+		name                  string
+		gvr                   schema.GroupVersionResource
+		expectedClusterScoped bool
+		expectedError         bool
+	}{
+		{
+			name: "namespaced resource (test group)",
+			gvr: schema.GroupVersionResource{
+				Group:    "test",
+				Version:  "v1",
+				Resource: "resources",
+			},
+			expectedClusterScoped: false,
+			expectedError:         false,
+		},
+		{
+			name: "cluster-scoped resource (core group)",
+			gvr: schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "namespaces",
+			},
+			expectedClusterScoped: true,
+			expectedError:         false,
+		},
+		{
+			name: "cluster-scoped resource (rbac group)",
+			gvr: schema.GroupVersionResource{
+				Group:    "rbac.authorization.k8s.io",
+				Version:  "v1",
+				Resource: "clusterroles",
+			},
+			expectedClusterScoped: true,
+			expectedError:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMapper := mock.NewRESTMapper()
+
+			isClusterScoped, err := isResourceClusterScoped(mockMapper, tt.gvr)
+
+			if (err != nil) != tt.expectedError {
+				t.Errorf("expected error %v, got %v", tt.expectedError, err)
+			}
+
+			if isClusterScoped != tt.expectedClusterScoped {
+				t.Errorf("expected isClusterScoped=%v, got %v", tt.expectedClusterScoped, isClusterScoped)
 			}
 		})
 	}

--- a/internal/mock/rest_mapper.go
+++ b/internal/mock/rest_mapper.go
@@ -1,0 +1,89 @@
+// Package mock provides a set of utilities for wrapping REST mappers
+package mock
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// RESTMapper is a mock implementation of meta.RESTMapper
+type RESTMapper struct{}
+
+// NewRESTMapper creates a new mock RESTMapper
+func NewRESTMapper() *RESTMapper {
+	return &RESTMapper{}
+}
+
+// KindFor returns a simple GVK based on the GVR
+func (m *RESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{
+		Group:   resource.Group,
+		Version: resource.Version,
+		Kind:    "Resource",
+	}, nil
+}
+
+// KindsFor returns a list of potential kinds
+func (m *RESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	gvk, err := m.KindFor(resource)
+	if err != nil {
+		return nil, err
+	}
+	return []schema.GroupVersionKind{gvk}, nil
+}
+
+// ResourceFor returns the input resource
+func (m *RESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return input, nil
+}
+
+// ResourcesFor returns a list containing the input resource
+func (m *RESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return []schema.GroupVersionResource{input}, nil
+}
+
+// RESTMapping returns a REST mapping for the provided group kind
+// For testing purposes, this uses simplified scope detection:
+//   - Resources in core group ("") or rbac group are treated as cluster-scoped (RESTScopeRoot)
+//   - All other resources (like "test" group) are treated as namespaced (RESTScopeNamespace)
+func (m *RESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	// Default to namespaced scope
+	scope := meta.RESTScopeNamespace
+
+	// Treat core and RBAC resources as cluster-scoped for testing
+	if gk.Group == "" || gk.Group == "rbac.authorization.k8s.io" {
+		scope = meta.RESTScopeRoot
+	}
+
+	return &meta.RESTMapping{
+		Resource: schema.GroupVersionResource{
+			Group:    gk.Group,
+			Version:  versions[0],
+			Resource: "resources",
+		},
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   gk.Group,
+			Version: versions[0],
+			Kind:    gk.Kind,
+		},
+		Scope: scope,
+	}, nil
+}
+
+// RESTMappings returns all resource mappings for the provided group kind
+func (m *RESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	mapping, err := m.RESTMapping(gk, versions...)
+	if err != nil {
+		return nil, err
+	}
+	return []*meta.RESTMapping{mapping}, nil
+}
+
+// ResourceSingularizer returns a singular version of the resource name
+func (m *RESTMapper) ResourceSingularizer(resource string) (string, error) {
+	// Simple singularization for testing
+	if len(resource) > 0 && resource[len(resource)-1] == 's' {
+		return resource[:len(resource)-1], nil
+	}
+	return resource, nil
+}

--- a/main.go
+++ b/main.go
@@ -26,9 +26,12 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 
 	"github.com/spectrocloud-labs/spectro-cleanup/internal/cleaner"
 )
@@ -127,6 +130,12 @@ func main() {
 		log.Fatal().Err(err).Msg("failed to create dynamic client")
 	}
 
+	discoveryC, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to create discovery client")
+	}
+	rm := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryC))
+
 	if err := c.CleanupFiles(); err != nil {
 		log.Fatal().Err(err).Msg("failed to cleanup files")
 	}
@@ -134,7 +143,7 @@ func main() {
 		Str("duration", time.Since(startTime).String()).
 		Msg("File cleanup complete")
 
-	if err := c.CleanupResources(ctx, dc); err != nil {
+	if err := c.CleanupResources(ctx, dc, rm); err != nil {
 		log.Fatal().Err(err).Msg("failed to cleanup resources")
 	}
 	log.Info().


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resource cleanup now correctly identifies and handles both cluster-scoped and namespaced Kubernetes resources during deletion operations.

* **Tests**
  * Added test coverage for cluster-scoped resource identification and validation.

* **Dependencies**
  * Updated dependencies for enhanced Kubernetes OpenAPI integration and utility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->